### PR TITLE
Fix dead sonoff TH_v1.1 devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .clang_complete
 .vscode
 .gcc-flags.json
+.idea
 lib/readme.txt
 *.pro.user*
 *.pro.user

--- a/platformio.ini
+++ b/platformio.ini
@@ -7,6 +7,7 @@ lib_deps =
   ArduinoJson@5.13.0
   HLW8012@1.1.0
   Embedis@1.2.0
+board_flash_mode = dout
 
 [env:sonoff]
 platform = ${common.platform_8266}
@@ -14,6 +15,7 @@ board = esp01_1m
 framework = ${common.framework}
 build_flags = ${common.build_flags} -DENABLE_SONOFF
 lib_deps = ${common.lib_deps}
+board_flash_mode = ${common.board_flash_mode}
 
 [env:sonoff-touch]
 platform = ${common.platform_8266}
@@ -21,6 +23,7 @@ board = esp8285
 framework = ${common.framework}
 build_flags = ${common.build_flags} -DENABLE_SONOFF_TOUCH
 lib_deps = ${common.lib_deps}
+board_flash_mode = ${common.board_flash_mode}
 
 [env:sonoff-s20]
 platform = ${common.platform_8266}
@@ -28,6 +31,7 @@ board = esp01_1m
 framework = ${common.framework}
 build_flags = ${common.build_flags} -DENABLE_SONOFF_S20
 lib_deps = ${common.lib_deps}
+board_flash_mode = ${common.board_flash_mode}
 
 [env:sonoff-touch-esp01]
 platform = ${common.platform_8266}
@@ -35,6 +39,7 @@ board = esp01_1m
 framework = ${common.framework}
 build_flags = ${common.build_flags} -DENABLE_SONOFF_TOUCH_ESP01
 lib_deps = ${common.lib_deps}
+board_flash_mode = ${common.board_flash_mode}
 
 [env:sonoff-pow]
 platform = ${common.platform_8266}
@@ -42,6 +47,7 @@ board = esp01_1m
 framework = ${common.framework}
 build_flags = ${common.build_flags} -DENABLE_SONOFF_POW
 lib_deps = ${common.lib_deps}
+board_flash_mode = ${common.board_flash_mode}
 
 [env:sonoff-switch]
 platform = ${common.platform_8266}
@@ -49,6 +55,7 @@ board = esp01_1m
 framework = ${common.framework}
 build_flags = ${common.build_flags} -DENABLE_SONOFF_SWITCH
 lib_deps = ${common.lib_deps}
+board_flash_mode = ${common.board_flash_mode}
 
 [env:sonoff-button]
 platform = ${common.platform_8266}
@@ -56,3 +63,4 @@ board = esp01_1m
 framework = ${common.framework}
 build_flags = ${common.build_flags} -DENABLE_SONOFF_BUTTON
 lib_deps = ${common.lib_deps}
+board_flash_mode = ${common.board_flash_mode}


### PR DESCRIPTION
Changed flash mode to `dout` to work with newer sonoff modules. Should be also compatible with old ones, but it's not tested.
